### PR TITLE
Added empty field return instead of -1 and cessation field

### DIFF
--- a/scripts/wof-csv-to-feature-collection
+++ b/scripts/wof-csv-to-feature-collection
@@ -101,7 +101,7 @@ if __name__ == '__main__':
             if options.keys_template == 'shapefile':
                 slim_keys = ['name','id','placetype','parent','country','region','locality','wof_a3','lbl_lat','lbl_long']
             elif options.keys_template == 'external_editor':
-                slim_keys = ['name','id','placetype','parent_id','is_landuse_aoi','supersedes','superseded_by','deprecated','eng_preferred_name','eng_variant_name', 'max_zoom','min_zoom','lbl_latitude','lbl_longitude','is_funky','is_hard_boundary','is_official','tier_locality','country_id','region_id','locality_id','wof_country']
+                slim_keys = ['name','id','placetype','parent_id','is_landuse_aoi','supersedes','superseded_by','deprecated','cessation','eng_preferred_name','eng_variant_name', 'max_zoom','min_zoom','lbl_latitude','lbl_longitude','is_funky','is_hard_boundary','is_official','tier_locality','country_id','region_id','locality_id','wof_country']
             elif options.keys_template == 'more':
                 slim_keys = ['name','id','placetype','parent_id','country_id','region_id','locality_id','wof_country','iso_country','lbl_latitude','lbl_longitude','inception','cessation','deprecated','supersedes','superseded_by','lastmodified','source']
         else:
@@ -270,7 +270,7 @@ if __name__ == '__main__':
                         fresh_props.update( { key: props[ property_aliases[key] ] } )
                 except:
                     logging.debug("\tmissing key: %s for %s" % (key, property_aliases[key]))
-                    fresh_props.update( { key: -1 } )
+                    fresh_props.update( { key: '' } )
             #print fresh_props
             # this won't be an ordered list, sadly
             if options.keys_template != "full":


### PR DESCRIPTION
Updated `external_editor` option with the following:

* Now includes `cessation` field.
* Returns an empty field value instead of `-1` for all NULL values.