### PR TITLE
Capture id row in wof-csv-to-feature-collection script

### DIFF
--- a/scripts/wof-csv-to-feature-collection
+++ b/scripts/wof-csv-to-feature-collection
@@ -153,8 +153,11 @@ if __name__ == '__main__':
                 wof_id = row.get('wof:id', None)
 
                 if wof_id == None:
-                    logging.error("missing wof:id column... how can --infer-path work... no, I mean really?")
-                    sys.exit(1)
+                    wof_id = row.get('id', None)
+                    
+                    if wof_id == None:
+                        logging.error("missing wof:id column... how can --infer-path work... no, I mean really?")
+                        sys.exit(1)
 
                 path = mapzen.whosonfirst.uri.id2relpath( wof_id )
 


### PR DESCRIPTION
The `whosonfirst-data` metafiles have `id` column - PR adds logic to use that column name, too.