### PR TITLE
Add show_path function

### DIFF
--- a/mapzen/whosonfirst/utils/__init__.py
+++ b/mapzen/whosonfirst/utils/__init__.py
@@ -299,6 +299,19 @@ def crawl(source, **kwargs):
 
             yield ret
 
+def show_path(source, **kwargs):
+
+    inflate = kwargs.get('inflate', False)
+
+    for (root, dirs, files) in os.walk(source):
+
+        for f in files:
+
+            path = os.path.join(root, f)
+            path = os.path.abspath(path)
+
+            yield path
+
 # this wraps ensure_valid_wof and returns True or False
 
 def is_valid_wof(path, **kwargs):


### PR DESCRIPTION
As part of https://github.com/whosonfirst-data/whosonfirst-data/issues/1714, I needed a method to grab each file path during a crawl of each repo. Perhaps there is a similar existing method that could do this, but this is a simple way to produce the full file path.